### PR TITLE
Add email-verifier package

### DIFF
--- a/src/CoreServiceProvider.php
+++ b/src/CoreServiceProvider.php
@@ -10,6 +10,7 @@ use Foundry\Core\Repositories\SettingRepository;
 use Foundry\Core\Requests\FormRequestHandler;
 use Illuminate\Support\Facades\Cache;
 use Foundry\Core\Console\Commands\MakeModuleCommand;
+use Foundry\Core\EmailVerifier\ServiceProvider as EmailVerifierServiceProvider;
 use Illuminate\Support\ServiceProvider;
 
 class CoreServiceProvider extends ServiceProvider {
@@ -84,6 +85,7 @@ class CoreServiceProvider extends ServiceProvider {
 	protected function registerProviders(): void {
 		$this->app->register( ConsoleServiceProvider::class );
 		$this->app->register( EventServiceProvider::class );
+        $this->app->register(EmailVerifierServiceProvider::class);
 	}
 
     /**

--- a/src/EmailVerifier/Contracts/EmailVerifiableInterface.php
+++ b/src/EmailVerifier/Contracts/EmailVerifiableInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Foundry\Core\EmailVerifier\Contracts;
+
+/**
+ * Contract for classes with verifiable emails using a code
+ */
+interface EmailVerifiableInterface
+{
+    /**
+     * Determines if email verified.
+     *
+     * @return  boolean  True if email verified, False otherwise.
+     */
+    public function isEmailVerified(): bool;
+
+    /**
+     * Gets the email verification date.
+     *
+     * @return  null|string  The email verification date.
+     */
+    public function getEmailVerifiedAt(): ?string;
+
+    /**
+     * Gets the email to verify
+     *
+     * @return  string  The email to verify
+     */
+    public function getVerifiableEmail(): string;
+
+    /**
+     * Gets the verification code.
+     *
+     * @return  null|string  The verification code.
+     */
+    public function getVerificationCode(): ?string;
+
+    /**
+     * Sets the email as verified.
+     */
+    public function setEmailAsVerified();
+
+    /**
+     * Sets the verification code.
+     *
+     * @param  string  $code  The code
+     */
+    public function setVerificationCode($code);
+}

--- a/src/EmailVerifier/EmailNotification.php
+++ b/src/EmailVerifier/EmailNotification.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Foundry\Core\EmailVerifier;
+
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Messages\MailMessage;
+
+/**
+ * Notification class for emails with a customizable message
+ */
+class EmailNotification extends Notification
+{
+    /** @var callable $builder callable for creating a MailMessage object */
+    protected $builder;
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param  callable  $builder  The builder
+     */
+    public function __construct($builder)
+    {
+        $this->builder = $builder;
+    }
+
+    /**
+     * Get the notification's channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array|string
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Build the mail representation of the notification.
+     *
+     * @param  mixed $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable): MailMessage
+    {
+        return call_user_func_array($this->builder, [$notifiable]);
+    }
+}

--- a/src/EmailVerifier/EmailVerifier.php
+++ b/src/EmailVerifier/EmailVerifier.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Foundry\Core\EmailVerifier;
+
+use Exception;
+use Foundry\Core\EmailVerifier\Notifier;
+
+/**
+ * Service for notifying and validating EmailVerifiable objects
+ */
+class EmailVerifier
+{
+    /** @var Notifier object for handling notifications */
+    protected $notifier = null;
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param  Notifier  $notifier  The notifier
+     */
+    public function __construct(Notifier $notifier)
+    {
+        $this->notifier = $notifier;
+    }
+
+    /**
+     * Verify email with code provided
+     *
+     * @param  EmailVerifiableInterface  $verifiable  The verifiable
+     * @param  string                    $code        The code
+     *
+     * @return  bool
+     */
+    public function verify(EmailVerifiableInterface $verifiable, string $code): bool
+    {
+        if ($verifiable->getVerificationCode() === $code) {
+            $verifiable->setEmailAsVerified();
+        }
+
+        return $verifiable->isEmailVerified();
+    }
+
+    /**
+     * Sends an email verification.
+     *
+     * @param  EmailVerifiableInterface  $verifiable  The verifiable
+     */
+    public function notify(EmailVerifiableInterface $verifiable)
+    {
+        $code = $this->generateVerificationCode();
+        $verifiable->setVerificationCode($code);
+
+        $this->getNotifier()->notify($verifiable);
+    }
+
+    /**
+     * Sets the notifier.
+     *
+     * @param  Notifier  $notifier  The dispatcher
+     *
+     * @return static
+     */
+    public function setNotifier(Notifier $notifier)
+    {
+        $this->notifier = $notifier;
+
+        return $this;
+    }
+
+    /**
+     * Gets the notifier.
+     *
+     * @throws  Exception  if not notifier is set
+     *
+     * @return  Notifier  The notifier.
+     */
+    public function getNotifier(): Notifier
+    {
+        return $this->notifier;
+    }
+
+    /**
+     * Accept a callable that will provide a MailMessage object to send as notification
+     *
+     * @param  callable  $callable  The callable
+     *
+     * @return  self
+     */
+    public function setMailBuilder(callable $callable)
+    {
+        $this->notifier = $this->getNotifier()->withMessage($callable);
+
+        return $this;
+    }
+
+    /**
+     * Simple utility function for generating a random code
+     *
+     * @return  string
+     * @todo create a customizable implementation of a code generator
+     */
+    protected function generateVerificationCode(): string
+    {
+        return mt_rand(10000, 99999);
+    }
+}

--- a/src/EmailVerifier/Notifier.php
+++ b/src/EmailVerifier/Notifier.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Foundry\Core\EmailVerifier;
+
+use Foundry\Core\EmailVerifier\EmailNotification;
+use Illuminate\Contracts\Notifications\Dispatcher;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Facades\Lang;
+
+class Notifier
+{
+    /** @var Dispatcher object for handling notifications */
+    protected $dispatcher;
+
+    protected $messageBuilder;
+
+    public function __construct(Dispatcher $dispatcher, callable $messageBuilder = null)
+    {
+        $this->dispatcher = $dispatcher;
+        $this->messageBuilder = $messageBuilder;
+    }
+
+    public function withMessage(callable $messageBuilder)
+    {
+        return new static($this->dispatcher, $messageBuilder);
+    }
+
+    protected function getMessageBuilder()
+    {
+        if ($this->messageBuilder !== null) {
+            return $this->messageBuilder;
+        }
+
+        $builder = function ($notifiable) {
+            return (new MailMessage())
+                ->subject(Lang::get('Verify Email Address'))
+                ->line(Lang::get('Please enter the OTP code provided below'))
+                ->line(Lang::get($notifiable->getVerificationCode()))
+                ->line(Lang::get('If you did not create an account, no further action is required.'));
+        };
+
+        return $builder;
+    }
+
+    public function notify(EmailVerifiableInterface $verifiable)
+    {
+        $notification = new EmailNotification($this->getMessageBuilder());
+
+        return $this->dispatcher->send($verifiable, $notification);
+    }
+}

--- a/src/EmailVerifier/ServiceProvider.php
+++ b/src/EmailVerifier/ServiceProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Foundry\Core\EmailVerifier;
+
+use Foundry\Core\EmailVerifier\EmailVerifier;
+use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+
+class ServiceProvider extends BaseServiceProvider
+{
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->bind('email.verifier', EmailVerifier::class);
+    }
+}

--- a/src/EmailVerifier/Traits/HasVerifiableEmail.php
+++ b/src/EmailVerifier/Traits/HasVerifiableEmail.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Foundry\Core\EmailVerifier\Traits;
+
+use Exception;
+use Illuminate\Support\Facades\Date;
+
+/**
+ * Model has a verifiable email using a code
+ *
+ * @method mixed getAttribute(string $key)
+ * @method mixed setAttribute(string $key, mixed $value)
+ */
+trait HasVerifiableEmail
+{
+    /**
+     * Determines if email verified.
+     *
+     * @return  boolean  True if email verified, False otherwise.
+     */
+    public function isEmailVerified(): bool
+    {
+        return ($this->getEmailVerifiedAt() !== null);
+    }
+
+    /**
+     * Gets the email verification date.
+     *
+     * @return  null|string  The email verification date.
+     */
+    public function getEmailVerifiedAt(): ?string
+    {
+        $column = defined('static::EMAIL_VERIFIER_DATE_COLUMN') ? static::EMAIL_VERIFIER_DATE_COLUMN : 'email_verified_at';
+
+        return $this->getAttribute($column);
+    }
+
+    /**
+     * Gets the email to verify
+     *
+     * @return  string  The email to verify
+     */
+    public function getVerifiableEmail(): string
+    {
+        $column = defined('static::EMAIL_VERIFIER_EMAIL_COLUMN') ? static::EMAIL_VERIFIER_EMAIL_COLUMN : 'email';
+
+        return $this->getAttribute($column);
+    }
+
+    /**
+     * Gets the verification code.
+     *
+     * @return  null|string  The verification code.
+     */
+    public function getVerificationCode(): ?string
+    {
+        $column = defined('static::EMAIL_VERIFIER_VERIFICATION_CODE_COLUMN') ? static::EMAIL_VERIFIER_VERIFICATION_CODE_COLUMN : 'email_verification_code';
+
+        return $this->getAttribute($column);
+    }
+
+    /**
+     * Sets the email as verified.
+     */
+    public function setEmailAsVerified()
+    {
+        $this->setAttribute($this->emailVerifiableCode, "");
+        $this->setAttribute($this->emailVerifiableDate, Date::now());
+        $this->save();
+    }
+
+    /**
+     * Sets the verification code.
+     *
+     * @param  string  $code  The code
+     */
+    public function setVerificationCode($code)
+    {
+        $this->setAttribute($this->emailVerifiableCode, $code);
+        $this->save();
+    }
+}


### PR DESCRIPTION
Added it similar to how the sub-packages in `laravel/framework` does it. 

Aware that it's structured differently. I initially tried to put them on their respective directories but made it a sub-package instead.
Let me know your thoughts.